### PR TITLE
feat: Allow writePb to use space=2 when stringifing dagNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,9 @@ const stringifyCid = (cid) => {
   return cid.toBaseEncodedString()
 }
 
-const writePb = async (ipfs, obj) => {
-  const buffer = Buffer.from(JSON.stringify(obj))
+const writePb = async (ipfs, obj, options = {}) => {
+  const str = options.legacy ? JSON.stringify(obj, null, 2) : JSON.stringify(obj)
+  const buffer = Buffer.from(str)
   const dagNode = await createPbDagNode(buffer)
 
   const cid = await ipfs.dag.put(dagNode, {


### PR DESCRIPTION
This PR simply allows you to pass an option to the `writePb` function that uses a different stringify format.

Maybe `legacy` is not the right word here? I'm open to suggestions.